### PR TITLE
PP-8512: Archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## GOV.UK Pay git timeline
 
+> As of September 2021 this repository is no longer actively maintained by the GOV.UK Pay team.
+
 This is a quick hack to generate a single timeline of merges to master on multiple git repositories.
 
 The list of repositories and the starting commit are hard-coded in the script.


### PR DESCRIPTION
This repository has had no activity for 5 years. It was used to display git commits across locally checked-out repositories. 

Archiving as part of our efforts to streamline Pay's repositories.